### PR TITLE
Android 9 FOREGROUND_SERVICE permission fix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:persistent="true"


### PR DESCRIPTION
I've got a 'java.lang.SecurityException: Permission Denial: startForeground' when launching the app on my Pixel 2 XL Android 9.

[Since Android9
Apps wanting to use foreground services must now request the FOREGROUND_SERVICE permission first. This is a normal permission, so the system automatically grants it to the requesting app. Starting a foreground service without the permission throws a SecurityException.](https://stackoverflow.com/questions/52382710/permission-denial-startforeground-requires-android-permission-foreground-servic)

So I added the permission and the app works now.