### PR TITLE
try to add editable attribute to node when dumpWindowHierarchy

### DIFF
--- a/app/src/androidTest/java/com/github/uiautomator/stub/AccessibilityNodeInfoDumper.java
+++ b/app/src/androidTest/java/com/github/uiautomator/stub/AccessibilityNodeInfoDumper.java
@@ -130,6 +130,7 @@ class AccessibilityNodeInfoDumper {
         serializer.attribute("", "visible-to-user", Boolean.toString(node.isVisibleToUser()));
         serializer.attribute("", "bounds", AccessibilityNodeInfoHelper.getVisibleBoundsInScreen(
                 node, width, height, false).toShortString());
+        serializer.attribute("", "editable", Boolean.toString(node.isEditable()));
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             serializer.attribute("", "drawing-order",
                     Integer.toString(Api24Impl.getDrawingOrder(node)));


### PR DESCRIPTION
获取的节点，增加editable属性，这个属性是辅助功能默认支持的。增加之后，部分输入框组件该属性为true。示例：

class=\"android.widget.EditText\" content-desc=\"\" checkable=\"false\" checked=\"false\" clickable=\"true\" enabled=\"true\" focusable=\"true\" focused=\"true\" scrollable=\"false\" long-clickable=\"true\" password=\"false\" selected=\"false\" visible-to-user=\"true\" bounds=\"[154,115][769,218]\" editable=\"true\" drawing-order=\"2\" hint=\"年中策略会|5天5场 首席前瞻机会\" display-id=\"0\" />\r\n

issues中有类似反馈 https://github.com/openatx/uiautomator2/issues/957